### PR TITLE
Fix binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # A replication by [Mateo Velásquez-Giraldo](https://mv77.github.io/) and [Matthew Zahn](https://sites.google.com/view/matthew-v-zahn/matthew-v-zahn).
 
 **Quick launch**: the following link launches a Jupyter notebook with the main results.
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthew-zahn/CGMPort/master?filepath=CGMPort-Public%2FCode%2FPython%2FCGM_REMARK.ipynb) **TODO: Point link to REMARK repo after merge. Currently points to MVZ's repo.**
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/econ-ark/CGMPortfolio/master?filepath=Code%2FPython%2FCGMPortfolio.ipynb)
 
 ## Description
 


### PR DESCRIPTION
Fixes the binder link, which pointed to Matt's old repo.